### PR TITLE
Add docs/ directory with initial placeholder files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # first-repo
 This is a test repo
+
+---
+
+## Documentation
+For in-repo documentation and guides, see `docs/README.md`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,14 @@
+# Documentation
+
+Welcome to the project documentation. This `docs/` directory contains guides and artifacts to help contributors and users get started.
+
+## Table of contents
+
+- [Getting started](getting-started.md)
+- [Architecture](architecture.md)
+- [Contributing to docs](contributing.md)
+- [Examples](examples/)
+
+---
+
+More detailed documentation will be added in follow-up PRs.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,9 @@
+# Architecture
+
+This short page describes the repository layout and high-level design.
+
+- `docs/` — project documentation and examples
+- `src/` / `lib/` — (if present) the main source code
+- `tests/` — (if present) test suites and CI configuration
+
+Add diagrams, a detailed component breakdown, and pointers to notable modules when ready.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,10 @@
+# Contributing to documentation
+
+Thanks for helping improve documentation! A short checklist to get started:
+
+1. Fork the repository and create a feature branch (e.g. `docs/update-setup`)
+2. Add or update a doc under `docs/`
+3. Run any formatting or linters the project uses for docs
+4. Open a pull request referencing this issue (#1)
+
+Please follow project contribution guidelines and keep changes small and focused.

--- a/docs/examples/hello-world.md
+++ b/docs/examples/hello-world.md
@@ -1,0 +1,11 @@
+# Example: Hello World
+
+A minimal example to show how the project is intended to be used.
+
+(Replace this with a short runnable example or sample file.)
+
+```text
+Hello world placeholder
+```
+
+Add real examples here to help new users.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,17 @@
+# Getting Started
+
+This page explains how to run and test the project locally.
+
+## Prerequisites
+- Git
+- Any language/runtime needed by the project
+
+## Quick start
+1. Clone the repository
+```bash
+git clone https://github.com/shubh-mishra711/first-repo.git
+cd first-repo
+```
+2. Read other docs pages in the `docs/` directory for more details.
+
+These are placeholder steps — update them with real instructions relevant to the project.


### PR DESCRIPTION
This PR adds a top-level `docs/` directory with initial placeholder documentation files and a small examples folder. It also adds a link in the root README to `docs/README.md`.

Related issue: #1

Files added:
- docs/README.md
- docs/getting-started.md
- docs/architecture.md
- docs/contributing.md
- docs/examples/hello-world.md

Once reviewed, follow-up PRs can add full content, diagrams, and runnable examples.